### PR TITLE
Fixes due to recent changes in python and numpy/scipy/jupyter

### DIFF
--- a/dsharp_opac/dsharp_opac.py
+++ b/dsharp_opac/dsharp_opac.py
@@ -16,7 +16,7 @@ import socket
 from importlib.resources import files
 import astropy.constants as const
 from pathlib import Path
-from scipy.interpolate import interp2d, RegularGridInterpolator, RectBivariateSpline
+from scipy.interpolate import RegularGridInterpolator, RectBivariateSpline
 
 au = const.au.cgs.value
 M_sun = const.M_sun.cgs.value

--- a/dsharp_opac/optical_constants/jaeger/links.json
+++ b/dsharp_opac/optical_constants/jaeger/links.json
@@ -1,6 +1,6 @@
 {
-    "Jaeger et al. 1998, cel1000": "http://www.astro.uni-jena.de/Laboratory/OCDB/data/carbon/cel1000.lnk",
-    "Jaeger et al. 1998, cel800": "http://www.astro.uni-jena.de/Laboratory/OCDB/data/carbon/cel800.lnk",
-    "Jaeger et al. 1998, cel600": "http://www.astro.uni-jena.de/Laboratory/OCDB/data/carbon/cel600.lnk",
-    "Jaeger et al. 1998, cel400": "http://www.astro.uni-jena.de/Laboratory/OCDB/data/carbon/cel400.lnk"
+    "Jaeger et al. 1998, cel1000": "http://www2.astro.uni-jena.de/Laboratory/OCDB/data/carbon/cel1000.txt",
+    "Jaeger et al. 1998, cel800": "http://www2.astro.uni-jena.de/Laboratory/OCDB/data/carbon/cel800.txt",
+    "Jaeger et al. 1998, cel600": "http://www2.astro.uni-jena.de/Laboratory/OCDB/data/carbon/cel600.txt",
+    "Jaeger et al. 1998, cel400": "http://www2.astro.uni-jena.de/Laboratory/OCDB/data/carbon/cel400.txt"
 }

--- a/notebooks/header.py
+++ b/notebooks/header.py
@@ -1,7 +1,10 @@
 from IPython import get_ipython
 ipython = get_ipython()
 if ipython is not None:
-    ipython.magic(u'matplotlib inline')
+    try:
+        ipython.magic(u'matplotlib inline')
+    except AttributeError:
+        ipython.run_line_magic('matplotlib', 'inline')
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/notebooks/opac_widget.py
+++ b/notebooks/opac_widget.py
@@ -75,7 +75,7 @@ par_ini   = [T,    v_frag, alpha, sigma_g]  # noqa - initial parameter value
 n_grid    = [10,   10,     10,    10]       # noqa - number of parameter values
 n_params  = len(par_names)
 par_grid = [
-    np.logspace(np.log10(p_start), np.log10(p_end), _n)
+    np.geomspace(p_start, p_end, _n)
     for p_start, p_end, _n in zip(par_start, par_end, n_grid)
     ]
 
@@ -104,15 +104,15 @@ k_ext_p_d = (k_ext_d.T * power_law[None, :]).sum(1)
 for it, _T in enumerate(par_grid[0]):
     Bnu    = aux.planck_B_nu(nu, _T)
     dBnudT = aux.planck_dBnu_dT(nu, _T)
-    B      = np.trapz(Bnu, x=nu)
-    dBdT   = np.trapz(dBnudT, x=nu)
+    B      = np.trapezoid(Bnu, x=nu)
+    dBdT   = np.trapezoid(dBnudT, x=nu)
 
     if _T < 170:
-        k_P_pf[it]  = np.trapz(Bnu * k_abs_p_w, x=nu) / B
-        k_R_pf[it]  = dBdT / np.trapz(dBnudT / k_ext_p_w, x=nu)
+        k_P_pf[it]  = np.trapezoid(Bnu * k_abs_p_w, x=nu) / B
+        k_R_pf[it]  = dBdT / np.trapezoid(dBnudT / k_ext_p_w, x=nu)
     else:
-        k_P_pf[it]  = np.trapz(Bnu * k_abs_p_d, x=nu) / B
-        k_R_pf[it]  = dBdT / np.trapz(dBnudT / k_ext_p_d, x=nu)
+        k_P_pf[it]  = np.trapezoid(Bnu * k_abs_p_d, x=nu) / B
+        k_R_pf[it]  = dBdT / np.trapezoid(dBnudT / k_ext_p_d, x=nu)
 
 # --------------------
 # DEFINE DATA FUNCTION
@@ -129,7 +129,6 @@ def get_data(values):
         T, a, r=r, sigma_g=sigma_g, d2g=d2g, rho_s=rho_s, M_star=M_star,
         v_frag=v_frag, alpha=alpha)
     f1 = f1 / f1.sum()
-
     # get the size distribution fit number 2
 
     f2, amax = opacity.get_B11S_fit(
@@ -166,18 +165,18 @@ def get_data(values):
 
     Bnu    = aux.planck_B_nu(nu, T)
     dBnudT = aux.planck_dBnu_dT(nu, T)
-    B      = np.trapz(Bnu, x=nu)
+    B      = np.trapezoid(Bnu, x=nu)
 
-    k_P_f1 = np.trapz(Bnu * k_abs_f1, x=nu) / B
-    k_P_f2 = np.trapz(Bnu * k_abs_f2, x=nu) / B
-    k_P_pl = np.trapz(Bnu * k_abs_pl, x=nu) / B
+    k_P_f1 = np.trapezoid(Bnu * k_abs_f1, x=nu) / B
+    k_P_f2 = np.trapezoid(Bnu * k_abs_f2, x=nu) / B
+    k_P_pl = np.trapezoid(Bnu * k_abs_pl, x=nu) / B
 
     # calculate Rosseland opacity for the fit and the power-law
 
-    dBdT   = np.trapz(dBnudT, x=nu)
-    k_R_f1 = dBdT / np.trapz(dBnudT / k_ext_f1, x=nu)
-    k_R_f2 = dBdT / np.trapz(dBnudT / k_ext_f2, x=nu)
-    k_R_pl = dBdT / np.trapz(dBnudT / k_ext_pl, x=nu)
+    dBdT   = np.trapezoid(dBnudT, x=nu)
+    k_R_f1 = dBdT / np.trapezoid(dBnudT / k_ext_f1, x=nu)
+    k_R_f2 = dBdT / np.trapezoid(dBnudT / k_ext_f2, x=nu)
+    k_R_pl = dBdT / np.trapezoid(dBnudT / k_ext_pl, x=nu)
 
     return {
         'f1': f1,


### PR DESCRIPTION
I found a few problems trying to use the package python 3.12 and the latest scipy/numpy versions etc.

The main things are:

- scipy's `interp2d` has been deprecated. I replaced this with `RectBivariateSpline`
- numpy's `trapz` is deprecated. It currently prints lots of warnings - I replaced it with `np.trapezoid`, which does the same thing.
- There was a floating point (rounding) issue with `np.log10` and `np.logspace` causing problems with limits on the dielectric constants. Switching to `np.geomspace` avoids this
- `ipython.magic` has been replaced by `ipython.run_line_magic`
- There were dead links to the Jaeger optical constants