### PR TITLE
DEP: add missing lower bounds on all dependencies

### DIFF
--- a/dsharp_opac/dsharp_opac.py
+++ b/dsharp_opac/dsharp_opac.py
@@ -10,7 +10,6 @@ import numpy as np
 import os
 import sys
 import warnings
-import importlib
 from contextlib import contextmanager
 import socket
 from importlib.resources import files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
-build-backend = 'mesonpy'
-requires = ['meson-python', 'numpy']
+build-backend = "mesonpy"
+requires = [
+    "meson-python>=0.18.0",
+    "numpy>=2.0.0",
+]
 
 [project]
 name = 'dsharp_opac'
@@ -11,7 +14,20 @@ authors = [
     { name = "Til Birnstiel & DSHARP collaboration", email = "til.birnstiel@lmu.de" },
 ]
 license = { file = 'LICENSE' }
-dependencies = ['numpy', 'scipy', 'matplotlib', 'astropy', 'mpmath', 'setuptools']
+dependencies = [
+    "numpy>=1.26.0",
+    "scipy>=1.13.0",
+    "matplotlib>=3.9.0",
+    "astropy>=7.0.0",
+
+    # only need mpmath.findroot, which I suspect scipy.optimize.fsolve can replace
+    "mpmath>=1.3.0",
+]
 
 [project.urls]
 Repository = "https://github.com/birnstiel/dsharp_opac/"
+
+[project.optional-dependencies]
+jit = [
+    "numba>=0.64.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ authors = [
 license = { file = 'LICENSE' }
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.26.0",
+    "numpy>=2.1.0",
     "scipy>=1.13.0",
-    "matplotlib>=3.9.0",
+    "matplotlib>=3.8.0",
     "astropy>=7.0.0",
 
     # only need mpmath.findroot, which I suspect scipy.optimize.fsolve can replace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
     { name = "Til Birnstiel & DSHARP collaboration", email = "til.birnstiel@lmu.de" },
 ]
 license = { file = 'LICENSE' }
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.26.0",
     "scipy>=1.13.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-setuptools
-numpy
-numba
-scipy
-matplotlib
-astropy
-ipython
-mpmath
+.[jit]
+ipython>=8.0.0


### PR DESCRIPTION
To facilitate downstream testing, I propose specifying lower bounds on all direct dependencies. Specifically, this helps when testing against a dependency tree resolved to lowest version (such as obtained with `uv pip install --resolution=lowest ...` for instance).

Since I couldn't find tests modules, I took a guess for each of them, roughly using https://scientific-python.org/specs/spec-0000/ as a basic specification.

I also found a couple quirks:
- `setuptools` looks like a dangling dependency so I removed it
- the only bit that's actually used from `mpmath` is `mpmath.findroot`, which I strongly suspect could be replaced by `scipy.optimize.fsolve`, which would allow dropping this dependency entirely.
