### PR TITLE
DEP: adjust requirement on CPython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     { name = "Til Birnstiel & DSHARP collaboration", email = "til.birnstiel@lmu.de" },
 ]
 license = { file = 'LICENSE' }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "numpy>=2.1.0",
     "scipy>=1.13.0",


### PR DESCRIPTION
A follow up to #9 after I realized that astropy 7.0.0 didn't support Python 3.10 so the requirements I defined there were slightly inconsistent.
An alternative would be to lower to requirement on astropy but I wouldn't recommend it, at least for now, since there are no actual tests to exercise these lower boundaries.