### PR TITLE
DEP: drop mpmath as a depdendency, replaced with scipy

### DIFF
--- a/dsharp_opac/dsharp_opac.py
+++ b/dsharp_opac/dsharp_opac.py
@@ -1423,7 +1423,8 @@ class diel_mixed():
         k : float
         :    imaginary part of mixed optical property
         """
-        from mpmath import findroot
+        from scipy.optimize import newton
+
         l_arr = np.array(lam, ndmin=1)
         eps_mean = np.empty(np.shape(l_arr)).astype('complex')
 
@@ -1439,7 +1440,7 @@ class diel_mixed():
                 #
                 def fct(x):
                     return sum(self.abundances * ((eps - x) / (eps + 2 * x)))
-                eps_mean[i] = complex(findroot(fct, complex(0.5, 0.5)))
+                eps_mean[i] = newton(fct, x0=(0.5 + 0.5j))
             elif self.rule.lower() == 'maxwell-garnett':
                 #
                 # kataoka et al. 2014, eq. 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,6 @@ dependencies = [
     "scipy>=1.13.0",
     "matplotlib>=3.8.0",
     "astropy>=7.0.0",
-
-    # only need mpmath.findroot, which I suspect scipy.optimize.fsolve can replace
-    "mpmath>=1.3.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
I think this is the correct replacement. However, I note that in my experiments with it, I hit some warnings in numpy, triggered from scipy:

```
/Users/clm/dev/gh/birnstiel/dsharp_opac/.venv/lib/python3.14/site-packages/scipy/_lib/array_api_compat/numpy/_aliases.py:106: ComplexWarning: Casting complex values to real discards the imaginary part
```

suggesting that scipy is maybe not solving correctly in the complex domain, or at the very least that it's doing something weird with numpy's API. I can probably dig it down further there, and I'll keep this PR as a draft until then.