### PR TITLE
CLN: remove unused `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,0 @@
-include README.md
-include LICENSE
-include dsharp_opac/optical_constants/*/*
-include dsharp_opac/optical_constants/*/*/*
-include dsharp_opac/*.f90
-include dsharp_opac/data/*.*
-include notebooks/*.ipynb
-include notebooks/*.py


### PR DESCRIPTION
this file is `setuptools` specific and is not used since the build system was switched to meson